### PR TITLE
[CRANKER] Activate preflight for liquidation

### DIFF
--- a/cranker/src/lib.rs
+++ b/cranker/src/lib.rs
@@ -278,7 +278,7 @@ async fn run_liquidation(
                     connection.send_transaction_with_config(
                         &tr,
                         RpcSendTransactionConfig {
-                            skip_preflight: true,
+                            skip_preflight: false,
                             preflight_commitment: None,
                             ..RpcSendTransactionConfig::default()
                         },


### PR DESCRIPTION
This change enables liquidation crankers to stop paying fees on no-op transactions.