### PR TITLE
[MINOR] Fix get_position util to not require mutable slice as input

### DIFF
--- a/program/src/state/user_account.rs
+++ b/program/src/state/user_account.rs
@@ -160,7 +160,7 @@ pub fn remove_position(
 }
 
 pub fn get_position(
-    user_account_data: &mut [u8],
+    user_account_data: &[u8],
     user_account_header: &UserAccountState,
     position_index: u16,
 ) -> Result<OpenPosition, ProgramError> {
@@ -175,7 +175,7 @@ pub fn get_position(
     let offset_end = offset.checked_add(OpenPosition::LEN).unwrap();
 
     let slice = user_account_data
-        .get_mut(offset..offset_end)
+        .get(offset..offset_end)
         .ok_or(ProgramError::InvalidArgument)?;
     OpenPosition::unpack_unchecked(slice)
 }


### PR DESCRIPTION
This PR fixes the get_position util's signature to require an unmutable slice. This is necessary for the util to be used in CPI.