### PR TITLE
[PROGRAM] Add minimal funding for imbalanced markets

### DIFF
--- a/js/src/state.ts
+++ b/js/src/state.ts
@@ -3,6 +3,7 @@ import BN from "bn.js";
 import { Schema, deserializeUnchecked } from "borsh";
 import { AccountLayout } from "@solana/spl-token";
 import { PositionType } from "./instructions";
+import { throws } from "assert";
 
 export enum StateTag {
   Uninitialized,
@@ -328,6 +329,7 @@ export class MarketState {
         (this.openLongsVCoin / this.openShortsVCoin) * ratio,
         ratio
       );
+      fundingRatioShorts = Math.max(fundingRatioShorts, (ratio * 24) / 100);
       return { fundingRatioLongs, fundingRatioShorts };
     } else {
       let fundingRatioShorts = ratio;
@@ -335,6 +337,8 @@ export class MarketState {
         (this.openShortsVCoin / this.openLongsVCoin) * -ratio,
         -ratio
       );
+
+      fundingRatioLongs = Math.max(fundingRatioLongs, (ratio * 24) / 100);
       return { fundingRatioLongs, fundingRatioShorts };
     }
   }

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -27,6 +27,7 @@ use crate::{
 pub(crate) const MARGIN_RATIO: u64 = ((1u128 << 64) / 20) as u64; // 64 fixed point
 const FUNDING_PERIOD: u64 = 3_600; // in s
 const FUNDING_NORMALIZATION: u64 = 86400 / FUNDING_PERIOD; // in s
+const MINIMAL_FUNDING: u64 = (1 << 32) * FUNDING_NORMALIZATION / 100; // FP32 the minimum fraction of funding in an imbalanced market
 const HISTORY_PERIOD: u64 = 300; // in s
 pub const REBALANCING_MARGIN: i64 = 429496729; // FP32 the relative difference in longs vs shorts open interests which enables rebalancing.
 pub const REBALANCING_LEVERAGE: u64 = 1;

--- a/program/src/processor/funding_extraction.rs
+++ b/program/src/processor/funding_extraction.rs
@@ -152,7 +152,7 @@ pub fn process_funding_extraction(
         return Err(PerpError::Nop.into());
     }
 
-    let (funding_ratio, balanced_funding_ratio) = {
+    let (_funding_ratio, balanced_funding_ratio) = {
         let mut f = 1i128 << 32;
         let mut balanced_f = f;
         let cycle = market_state.funding_history.len();
@@ -172,13 +172,13 @@ pub fn process_funding_extraction(
         ((f - (1 << 32)) as i64, (balanced_f - (1 << 32)) as i64)
     };
 
-    let debt = -(((positions_v_coin.abs() as i128) * (funding_ratio as i128)) >> 32) as i64;
+    // let debt = -(((positions_v_coin.abs() as i128) * (funding_ratio as i128)) >> 32) as i64;
     let balanced_debt =
         -(((positions_v_coin.abs() as i128) * (balanced_funding_ratio as i128)) >> 32) as i64;
 
-    let rebalancing_funds = std::cmp::max(0, balanced_debt - debt);
+    // let rebalancing_funds = std::cmp::max(0, balanced_debt - debt);
 
-    market_state.rebalancing_funds += rebalancing_funds as u64;
+    // market_state.rebalancing_funds += rebalancing_funds as u64;
 
     if balanced_debt > (user_account_header.balance as i64) {
         msg!("This account has insufficient funds and must be liquidated");


### PR DESCRIPTION
This PR aims to add a minimal funding rate of 1bps / 1% spread (vs a maximum of 1/24 = 4.17 bps / 1% spread). This greatly improves incentives for arbitrageurs with large open positions.